### PR TITLE
IO-104076 | fix max call stack error

### DIFF
--- a/src/protocol/requests/fetch/v4/decodeMessages.js
+++ b/src/protocol/requests/fetch/v4/decodeMessages.js
@@ -25,7 +25,9 @@ const decodeMessages = async decoder => {
     while (messagesDecoder.canReadBytes(RECORD_BATCH_OVERHEAD)) {
       try {
         const recordBatch = await RecordBatchDecoder(messagesDecoder)
-        records.push(...recordBatch.records)
+        for(let i = 0; i < recordBatch.records.length; i++) {
+          records.push(recordBatch.records[i])
+        }
       } catch (e) {
         // The tail of the record batches can have incomplete records
         // due to how maxBytes works. See https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-FetchAPI


### PR DESCRIPTION
        -- records.push(...recordBatch.records)
        ++ for(let i = 0; i < recordBatch.records.length; i++) {
          records.push(recordBatch.records[i])
        }
        
        a large records  size (> 125k) causes the spread operator to use all of the stack and cause max call stack size error, converting it to regular for loop for better performace
        
ci check passed in original repo:        https://github.com/tulios/kafkajs/pull/1723
