### PR TITLE
Optimize groupMessagesPerPartition for single-partition batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.2.5] - 2026-05-23
+
+### Fixed
+  - Optimize `groupMessagesPerPartition` to avoid O(n²) array copies when grouping producer messages #4
+  - Fast-path single-partition batches when all messages share the same `partitionNumber` or `partition` (e.g. Celigo `flow_events` via `sendFlowEvents`)
+
 ## [2.2.4] - 2023-02-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kafkajs",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "A modern Apache Kafka client for node.js",
   "author": "Tulio Ornelas <ornelas.tulio@gmail.com>",
   "main": "index.js",

--- a/src/producer/groupMessagesPerPartition.js
+++ b/src/producer/groupMessagesPerPartition.js
@@ -1,11 +1,57 @@
+const getUniformExplicitPartition = messages => {
+  if (messages.length === 0) {
+    return null
+  }
+
+  const { partitionNumber } = messages[0]
+  if (
+    partitionNumber !== undefined &&
+    partitionNumber !== null &&
+    messages.every(message => message.partitionNumber === partitionNumber)
+  ) {
+    return partitionNumber
+  }
+
+  const { partition } = messages[0]
+  if (
+    partition !== undefined &&
+    partition !== null &&
+    messages.every(message => message.partition === partition)
+  ) {
+    return partition
+  }
+
+  return null
+}
+
 module.exports = ({ topic, partitionMetadata, messages, partitioner }) => {
   if (partitionMetadata.length === 0) {
     return {}
   }
 
-  return messages.reduce((result, message) => {
+  if (messages.length === 0) {
+    return {}
+  }
+
+  const uniformPartition = getUniformExplicitPartition(messages)
+  if (uniformPartition !== null) {
+    return { [uniformPartition]: messages }
+  }
+
+  if (messages.length === 1) {
+    const partition = partitioner({ topic, partitionMetadata, message: messages[0] })
+    return { [partition]: messages }
+  }
+
+  const result = {}
+  for (const message of messages) {
     const partition = partitioner({ topic, partitionMetadata, message })
-    const current = result[partition] || []
-    return Object.assign(result, { [partition]: [...current, message] })
-  }, {})
+    let bucket = result[partition]
+    if (!bucket) {
+      bucket = []
+      result[partition] = bucket
+    }
+    bucket.push(message)
+  }
+  return result
 }

--- a/src/producer/groupMessagesPerPartition.spec.js
+++ b/src/producer/groupMessagesPerPartition.spec.js
@@ -40,4 +40,63 @@ describe('Producer > groupMessagesPerPartition', () => {
       groupMessagesPerPartition({ topic, partitionMetadata: [], messages, partitioner })
     ).toEqual({})
   })
+
+  test('returns empty when called with no messages', () => {
+    expect(
+      groupMessagesPerPartition({ topic, partitionMetadata, messages: [], partitioner })
+    ).toEqual({})
+  })
+
+  test('reuses the messages array when every message has the same partitionNumber', () => {
+    const flowEventMessages = [
+      { value: 'a', partitionNumber: 2 },
+      { value: 'b', partitionNumber: 2 },
+      { value: 'c', partitionNumber: 2 },
+    ]
+    const explicitPartitioner = jest.fn()
+
+    const result = groupMessagesPerPartition({
+      topic,
+      partitionMetadata,
+      messages: flowEventMessages,
+      partitioner: explicitPartitioner,
+    })
+
+    expect(result).toEqual({ 2: flowEventMessages })
+    expect(result[2]).toBe(flowEventMessages)
+    expect(explicitPartitioner).not.toHaveBeenCalled()
+  })
+
+  test('reuses the messages array when every message has the same partition', () => {
+    const explicitPartitionMessages = [
+      { key: 'a', partition: 1 },
+      { key: 'b', partition: 1 },
+    ]
+    const explicitPartitioner = jest.fn()
+
+    const result = groupMessagesPerPartition({
+      topic,
+      partitionMetadata,
+      messages: explicitPartitionMessages,
+      partitioner: explicitPartitioner,
+    })
+
+    expect(result).toEqual({ 1: explicitPartitionMessages })
+    expect(result[1]).toBe(explicitPartitionMessages)
+    expect(explicitPartitioner).not.toHaveBeenCalled()
+  })
+
+  test('groups a single message without copying the array', () => {
+    const singleMessage = [{ key: 'only' }]
+
+    const result = groupMessagesPerPartition({
+      topic,
+      partitionMetadata,
+      messages: singleMessage,
+      partitioner,
+    })
+
+    expect(result).toEqual({ 0: singleMessage })
+    expect(result[0]).toBe(singleMessage)
+  })
 })


### PR DESCRIPTION
## Summary

- Replace O(n²) `[...current, message]` grouping with O(n) `push`-based buckets
- Fast-path when all messages share the same explicit partition (`partitionNumber` for Celigo flow events, or Kafka `partition`)
- Reuse the input `messages` array on the fast path (no per-message array copies)

## Background / why this change

### What we observed

While investigating **CPU / event-loop blockage** on `integrator-workers` (`sqstimeout` pod), CPU profiles (`cpuprofiles/cpublocks`) showed the process spending a large share of active CPU inside KafkaJS:

- **`groupMessagesPerPartition`** (~84–87% of active samples in long captures)
- Followed by **GC** (~12%), consistent with heavy short-lived allocations

Example hot stack:

```
groupMessagesPerPartition → createProducerRequests → sendMessages
```

### How Celigo uses this code

Flow events are sent via `message-processing-common` → `kafka-util` → `@celigo/kafkajs`:

1. `kafkaClient.sendFlowEvents(events, partitionNumber)` maps each event with `createFlowEvent(event, partitionNumber)`
2. `prepareAndSendData` builds a **new** wire batch: `{ value: <Avro buffer>, partitionNumber }` per message
3. `producer.send({ topic: 'flow_events', messages })` calls `groupMessagesPerPartition` before produce

For a given execution, **every message in the batch already has the same `partitionNumber`**. The custom partitioner in `kafkaUtil` returns `message.partitionNumber` when set — so routing was already correct; the cost was in **how** messages were grouped.

### Root cause in upstream KafkaJS

Previous implementation (per message):

```js
return Object.assign(result, { [partition]: [...current, message] })
```

Even when every message targets the **same partition**, this:

1. Invokes the partitioner **N times**
2. **Copies the entire partition array** on each append → **O(n²)** CPU and allocations

Large recovery / flush batches (many flow events in one `sendFlowEvents` call) could block the event loop for tens of seconds.

### What this PR does

| Case | Behavior |
|------|----------|
| All messages share the same `partitionNumber` or `partition` | Return `{ [p]: messages }` — **O(1)** grouping, no partitioner calls, **same array reference** |
| Single message | One partitioner call, reuse array |
| Mixed partitions (keys / round-robin) | O(n) `push` into per-partition buckets (same outcome as before, without spread copies) |

**No change** to which partition messages are assigned for the Celigo `flow_events` path when `partitionNumber` is set consistently (matches existing `customPartitioner` behavior).

## Risks / review notes

- **Reference sharing:** Fast path reuses the `messages` array passed into `producer.send`. Safe for Celigo today because `prepareAndSendData` creates a fresh `toSendClone` per send and does not mutate it afterward. Avoid reusing the same array across concurrent sends.
- **Partitioner skipped on fast path:** Only when every message agrees on `partitionNumber` or `partition`. If a caller set a uniform `partitionNumber` but expected key-based routing from a different partitioner, behavior would differ — **not** the Celigo `flow_events` path.
- **Does not fix:** Avro encoding, compression, or other CPU hotspots — only grouping before produce.

## Out of scope (follow-up after merge)

- Bump `@celigo/kafkajs` in `kafka-util` → `message-processing-common` → `integrator-workers`
- Re-profile after deploy to confirm reduced event-loop blockage on large `sendFlowEvents` batches

## Test plan

- [x] `jest src/producer/groupMessagesPerPartition.spec.js` (6 tests pass)
- [x] Existing mixed-partition grouping test unchanged
- [x] New tests: empty batch, uniform `partitionNumber`, uniform `partition`, single message
- [ ] Bump dependents after merge